### PR TITLE
#63 GitHub. Action. Docker Release Image Build/Push. Change trigger to release

### DIFF
--- a/.github/workflows/docker-release-image-build-push.yml
+++ b/.github/workflows/docker-release-image-build-push.yml
@@ -1,9 +1,8 @@
 name: Docker Release Image Build/Push
 
 on:
-  push:
-    tags:
-      - '**'
+  release:
+    types: [ published ]
 
 jobs:
   vue-js-app-build:


### PR DESCRIPTION
Changed trigger workflow 'Docker Release Image Build/Push' to on published release.