### PR TITLE
#63.3 GitHub. Action. Docker Release Image Build/Push. Change trigger to on after created release.

### DIFF
--- a/.github/workflows/docker-release-image-build-push.yml
+++ b/.github/workflows/docker-release-image-build-push.yml
@@ -2,7 +2,7 @@ name: Docker Release Image Build/Push
 
 on:
   release:
-    types: [published]
+    types: [ created ]
 
 jobs:
   vue-js-app-build:


### PR DESCRIPTION
Changed trigger workflow 'Docker Release Image Build/Push' to on after created release.