### PR TITLE
#63.4 GitHub. Action. Docker Release Image Build/Push. Change trigger to on after created or pushed tags

### DIFF
--- a/.github/workflows/docker-release-image-build-push.yml
+++ b/.github/workflows/docker-release-image-build-push.yml
@@ -1,8 +1,12 @@
 name: Docker Release Image Build/Push
 
 on:
-  release:
-    types: [ created ]
+  create:
+    tags:
+      - '**'
+  push:
+    tags:
+      - '**'
 
 jobs:
   vue-js-app-build:


### PR DESCRIPTION
Changed trigger workflow 'Docker Release Image Build/Push' to on after created or pushed tags.