### PR TITLE
#75 GitHub. Actions. Docker release image build/push. Remove trigger

### DIFF
--- a/.github/workflows/docker-release-image-build-push.yml
+++ b/.github/workflows/docker-release-image-build-push.yml
@@ -4,9 +4,6 @@ on:
   create:
     tags:
       - '**'
-  push:
-    tags:
-      - '**'
 
 jobs:
   vue-js-app-build:


### PR DESCRIPTION
Removed trigger on after push in tag for "Docker Release Image Build/Push" workflow.